### PR TITLE
Updates the POM to version 2.0.7 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.6</tag>
+      <tag>2.0.7</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>
@@ -156,7 +156,7 @@
         <checkstyleHeaderLocation>org/forgerock/checkstyle/default-java-header</checkstyleHeaderLocation>
         <checkstyleFailOnError>true</checkstyleFailOnError>
 
-        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version 
+        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version
              (useful when you have some constraints on a given version and if the parent doesn't give you the one you need ...) -->
 
         <!-- clirr-maven-plugin -->
@@ -220,7 +220,7 @@
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
 
         <!--  ForgeRock build tools version -->
-        <forgerockBuildToolsVersion>1.0.3</forgerockBuildToolsVersion>
+        <forgerockBuildToolsVersion>1.0.4</forgerockBuildToolsVersion>
 
         <!-- Forgerock binary license name -->
         <binary.license.name>Forgerock_License.txt</binary.license.name>
@@ -475,6 +475,10 @@
                             <version>${forgerockBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
+                    <configuration>
+                        <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
+                        <argLine>-Djava.awt.headless=true</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -774,7 +778,7 @@
                              to fail the build if source code does not comply with
                              our coding guidelines, and not at a later stage when
                              the site is generated (which may never occur for some
-                             projects).     
+                             projects).
                         -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -879,7 +883,7 @@
                     </plugin>
 
                     <!-- CheckStyle -->
-                    <plugin> 
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <version>${checkstylePluginVersion}</version>


### PR DESCRIPTION
Updates the POM to version 2.0.7 which is required for wren:am sustaining/13.5 branch. Changes are copied from the ForgeRock Maven POM file. See 'wrensec-deps' repository for the original file.