### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-parent)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export BINTRAY_PACKAGE="wrensec-parent"
+export JFROG_PACKAGE="org/forgerock/forgerock-parent/"
+export MAVEN_PACKAGE="forgerock-parent"

--- a/pom.xml
+++ b/pom.xml
@@ -56,25 +56,24 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-parent/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrensec-parent/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
 
     <!-- (see FAQ at http://maven.apache.org/guides/mini/guide-central-repository-upload.html ) -->
     <repositories>
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
-
+            <url>${forgerockDistMgmtReleasesUrl}</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -85,10 +84,9 @@
         </repository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -99,12 +97,11 @@
         </repository>
 
         <repository>
-            <id>bintray-wrensecurity-forgerock-archive</id>
+            <id>wrensecurity-forgerock-archive</id>
             <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
-            <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
-
+            <url>${forgerockVerifiedArchiveUrl}</url>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
 
             <releases>
@@ -115,45 +112,30 @@
 
     <pluginRepositories>
         <pluginRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Plugin Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
-
+            <url>${forgerockDistMgmtReleasesUrl}</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
         </pluginRepository>
 
         <pluginRepository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Plugin Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
-            </releases>
         </pluginRepository>
 
         <pluginRepository>
-            <id>bintray-wrensecurity-forgerock-archive</id>
+            <id>wrensecurity-forgerock-archive</id>
             <name>Wren Security Archive for Verified ForgeRock Plugins</name>
-            <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
-
+            <url>${forgerockVerifiedArchiveUrl}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
         </pluginRepository>
     </pluginRepositories>
 
@@ -259,8 +241,9 @@
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
-        <forgerockDistMgmtSnapshotsUrl>https://api.bintray.com/maven/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
-        <forgerockDistMgmtReleasesUrl>https://api.bintray.com/maven/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
+        <forgerockDistMgmtSnapshotsUrl>https://wrensecurity.jfrog.io/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
+        <forgerockDistMgmtReleasesUrl>https://wrensecurity.jfrog.io/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
+        <forgerockVerifiedArchiveUrl>http://dl.bintray.com/wrensecurity/forgerock-archive</forgerockVerifiedArchiveUrl>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,9 @@
         <!-- maven-release-plugin http://maven.apache.org/plugins/maven-release-plugin/ -->
         <mavenReleasePluginVersion>2.5.1</mavenReleasePluginVersion>
 
+        <!-- pgpverify-maven-plugin -->
+        <pgpVerifyPluginVersion>1.1.0</pgpVerifyPluginVersion>
+
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
@@ -627,7 +630,7 @@
                 <plugin>
                     <groupId>com.github.s4u.plugins</groupId>
                     <artifactId>pgpverify-maven-plugin</artifactId>
-                    <version>1.1.0</version>
+                    <version>${pgpVerifyPluginVersion}</version>
                 </plugin>
                 <plugin>
                     <!-- Check Open Source licenses for all the dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright 2011-2015 ForgeRock AS.
- Portions Copyright © 2017 Wren Security. All rights reserved.
+ Portions Copyright 2017 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License

--- a/pom.xml
+++ b/pom.xml
@@ -1330,4 +1330,18 @@
         </plugins>
     </reporting>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Ensure that the version specified for tools.jar matches the
+                 JDK version to retrieve the right GPG signature from the repo.
+              -->
+            <dependency>
+                <groupId>com.sun</groupId>
+                <artifactId>tools</artifactId>
+                <version>${java.version}</version>
+                <scope>system</scope>
+                <systemPath>${java.home}/../lib/tools.jar</systemPath>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright 2011-2015 ForgeRock AS.
+ Portions Copyright © 2017 Wren Security. All rights reserved.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -29,9 +30,9 @@
     <artifactId>forgerock-parent</artifactId>
     <version>2.0.6</version>
     <packaging>pom</packaging>
-    <name>ForgeRock Parent</name>
-    <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
-    <url>http://www.forgerock.com</url>
+    <name>Wren Security Parent</name>
+    <description>Parent POM for Wren Security (formerly ForgeRock) projects. Provides default project build configuration.</description>
+    <url>http://wrensecurity.org/</url>
     <licenses>
         <license>
             <name>CDDL-1.0</name>
@@ -41,70 +42,115 @@
         </license>
     </licenses>
     <organization>
-        <name>ForgeRock AS</name>
-        <url>http://www.forgerock.com</url>
+        <name>Wren Security</name>
+        <url>http://wrensecurity.org/</url>
     </organization>
     <issueManagement>
-        <system>jira</system>
-        <url>https://bugster.forgerock.org</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-parent/issues</url>
     </issueManagement>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.6</tag>
-  </scm>
+        <url>https://github.com/WrenSecurity/wrensec-parent</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-parent.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-parent.git</developerConnection>
+    </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>forgerock-snapshots</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-parent/;publish=1</url>
         </snapshotRepository>
+
         <repository>
-            <id>forgerock-staging</id>
-            <name>ForgeRock Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrensec-parent/;publish=1</url>
         </repository>
-        <site>
-            <id>community.internal.forgerock.com</id>
-            <name>ForgeRock Community</name>
-            <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-parent</url>
-        </site>
     </distributionManagement>
 
     <!-- (see FAQ at http://maven.apache.org/guides/mini/guide-central-repository-upload.html ) -->
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
             <releases>
                 <enabled>true</enabled>
             </releases>
         </repository>
+
         <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+
             <releases>
                 <enabled>false</enabled>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>bintray-wrensecurity-forgerock-archive</id>
+            <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
+            <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
+
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
             </releases>
         </repository>
     </repositories>
+
     <pluginRepositories>
         <pluginRepository>
-            <id>forgerock-plugins-repository</id>
-            <name>ForgeRock Plugin Repository</name>
-            <url>http://maven.forgerock.org/repo/plugins</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Plugin Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Plugin Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </pluginRepository>
+
+        <pluginRepository>
+            <id>bintray-wrensecurity-forgerock-archive</id>
+            <name>Wren Security Archive for Verified ForgeRock Plugins</name>
+            <url>http://dl.bintray.com/wrensecurity/forgerock-archive</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -156,7 +202,7 @@
         <checkstyleHeaderLocation>org/forgerock/checkstyle/default-java-header</checkstyleHeaderLocation>
         <checkstyleFailOnError>true</checkstyleFailOnError>
 
-        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version 
+        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version
              (useful when you have some constraints on a given version and if the parent doesn't give you the one you need ...) -->
 
         <!-- clirr-maven-plugin -->
@@ -213,8 +259,8 @@
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
-        <forgerockDistMgmtSnapshotsUrl>http://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
-        <forgerockDistMgmtReleasesUrl>http://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
+        <forgerockDistMgmtSnapshotsUrl>https://api.bintray.com/maven/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
+        <forgerockDistMgmtReleasesUrl>https://api.bintray.com/maven/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
@@ -594,6 +640,11 @@
                             </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.s4u.plugins</groupId>
+                    <artifactId>pgpverify-maven-plugin</artifactId>
+                    <version>1.1.0</version>
                 </plugin>
                 <plugin>
                     <!-- Check Open Source licenses for all the dependencies -->
@@ -1116,6 +1167,34 @@
                 <ci.build.number>0</ci.build.number>
                 <ci.scm.revision>0</ci.scm.revision>
             </properties>
+        </profile>
+        <profile>
+            <id>verify-artifact-sigs</id>
+            <activation>
+                <property>
+                    <name>!ignore-artifact-sigs</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.s4u.plugins</groupId>
+                        <artifactId>pgpverify-maven-plugin</artifactId>
+                        <configuration>
+                            <failNoSignature>true</failNoSignature>
+                            <keysMapLocation>http://wrensecurity.org/trustedkeys.properties</keysMapLocation>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
           <!-- This profile provides API/ABI compatiblity checks and reports via Clirr -->


### PR DESCRIPTION
- modifies the Wren Parent POMs to build using Wren's repos.
- updates branding to call this Wren Security Parent instead of ForgeRock Parent.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.