### PR TITLE
Always generate source JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -986,6 +986,14 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <!-- Publish also javadocs when releasing - required -->
                     <plugin>


### PR DESCRIPTION
Closes #4:
- Reverts "AME-9491 Use the execution from the maven super pom for source plugin" (commit 268d9fc).
- Similar changes have already been made to `sustaining/2.0.6` and `sustaining/2.0.7`.

this depends on https://github.com/WrenSecurity/wrensec-parent/pull/3 being reviewed + merged first.