### PR TITLE
[2.x] Upgrade PGP Verify + fix whitelist location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
-        <pgpVerifyWhitelist>http://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpVerifyWhitelist>https://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
 
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wrensecurity</groupId>
     <artifactId>wrensec-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Wren Security Parent</name>
     <description>Parent POM for Wren Security (formerly ForgeRock) projects. Provides default project build configuration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright 2011-2016 ForgeRock AS.
- Portions Copyright 2017 Wren Security.
+ Portions Copyright 2017-2018 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -26,8 +26,8 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.forgerock</groupId>
-    <artifactId>forgerock-parent</artifactId>
+    <groupId>org.wrensecurity</groupId>
+    <artifactId>wrensec-parent</artifactId>
     <version>2.0.10</version>
     <packaging>pom</packaging>
     <name>Wren Security Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <mavenReleasePluginVersion>2.5.1</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
-        <pgpVerifyPluginVersion>1.3.0-wren1</pgpVerifyPluginVersion>
+        <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
         <pgpVerifyWhitelist>http://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
 
         <!-- ***************** -->

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,8 @@
         <mavenReleasePluginVersion>2.5.1</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
-        <pgpVerifyPluginVersion>1.2.0-wren1</pgpVerifyPluginVersion>
+        <pgpVerifyPluginVersion>1.3.0-wren1</pgpVerifyPluginVersion>
+        <pgpVerifyWhitelist>http://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
 
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
@@ -639,7 +640,7 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.github.s4u.plugins</groupId>
+                    <groupId>org.simplify4u.plugins</groupId>
                     <artifactId>pgpverify-maven-plugin</artifactId>
                     <version>${pgpVerifyPluginVersion}</version>
                 </plugin>
@@ -1169,11 +1170,11 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.github.s4u.plugins</groupId>
+                        <groupId>org.simplify4u.plugins</groupId>
                         <artifactId>pgpverify-maven-plugin</artifactId>
                         <configuration>
                             <failNoSignature>true</failNoSignature>
-                            <keysMapLocation>http://wrensecurity.org/trustedkeys.properties</keysMapLocation>
+                            <keysMapLocation>${pgpVerifyWhitelist}</keysMapLocation>
                             <verifySnapshots>true</verifySnapshots>
                         </configuration>
                         <executions>


### PR DESCRIPTION
**NOTE:** This depends on https://github.com/WrenSecurity/wrensec-parent/pull/10

For projects that use the 2.x versions of `wrensec-parent`, this will fix the following issues:
- Cannot build with `mvn clean install` because inter-project dependencies in the same build ("reactor") fail to build.
- After recent changes to the Wren Security website, build fails with this error:
> [ERROR] Failed to execute goal com.github.s4u.plugins:pgpverify-maven-plugin:1.2.0-wren1:check (default) on project openam: Execution default of goal com.github.s4u.plugins:pgpverify-maven-plugin:1.2.0-wren1:check failed: Property line is malformed: <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"> -> [Help 1]

Closes #9.