### PR TITLE
[3.x] Create a new major release

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,3 +1,2 @@
 export BINTRAY_PACKAGE="wrensec-parent"
-export JFROG_PACKAGE="org/forgerock/forgerock-parent/"
-export MAVEN_PACKAGE="forgerock-parent"
+export MVN_COMPILE_ARGS="${WREN_DEFAULT_MVN_COMPILE_ARGS:-} -Pfull-release"

--- a/pom.xml
+++ b/pom.xml
@@ -1210,7 +1210,7 @@
 
             <activation>
                 <property>
-                    <name>env.JOB_NAME</name>
+                    <name>env.SCM_REVISION</name>
                 </property>
             </activation>
 

--- a/pom.xml
+++ b/pom.xml
@@ -164,19 +164,19 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- maven-compiler-plugin http://maven.apache.org/plugins/maven-compiler-plugin -->
-        <mavenCompilerPluginVersion>3.3</mavenCompilerPluginVersion>
+        <mavenCompilerPluginVersion>3.7.0</mavenCompilerPluginVersion>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
         <!-- maven-enforcer-plugin -->
-        <maven.min.version>3.0.1</maven.min.version>
+        <maven.min.version>3.2.1</maven.min.version>
         <jdk.min.version>${maven.compiler.source}</jdk.min.version>
 
         <!-- findbugs-maven-plugin -->
-        <findbugsPluginVersion>3.0.1</findbugsPluginVersion>
+        <findbugsPluginVersion>3.0.5</findbugsPluginVersion>
 
         <!-- maven-javadoc-plugin -->
-        <javadocPluginVersion>2.9</javadocPluginVersion>
+        <javadocPluginVersion>3.0.1</javadocPluginVersion>
         <!-- forgerock-build-tools stylesheet org/forgerock/javadoc/javadoc.css
              does not work with JDK7 -->
         <javadocStylesheet />
@@ -188,14 +188,14 @@
         <downloadJavadocs>true</downloadJavadocs>
 
         <!-- maven-pmd-plugin -->
-        <pmdPluginVersion>3.4</pmdPluginVersion>
+        <pmdPluginVersion>3.10.0</pmdPluginVersion>
         <targetJdk>${maven.compiler.target}</targetJdk>
 
         <!-- Checkstyle version -->
-        <checkstyleVersion>6.6</checkstyleVersion>
+        <checkstyleVersion>8.10.1</checkstyleVersion>
 
         <!-- maven-checkstyle-plugin -->
-        <checkstylePluginVersion>2.16</checkstylePluginVersion>
+        <checkstylePluginVersion>3.0.0</checkstylePluginVersion>
         <checkstyleSourceConfigLocation>org/forgerock/checkstyle/check-src-default.xml</checkstyleSourceConfigLocation>
         <checkstyleDocTargetConfigLocation>org/forgerock/checkstyle/check-src-doc-target.xml</checkstyleDocTargetConfigLocation>
         <checkstyleUnitTestSuppressionsLocation>org/forgerock/checkstyle/unit-test-suppressions.xml</checkstyleUnitTestSuppressionsLocation>
@@ -206,34 +206,34 @@
              (useful when you have some constraints on a given version and if the parent doesn't give you the one you need ...) -->
 
         <!-- clirr-maven-plugin -->
-        <clirrPluginVersion>2.6.1</clirrPluginVersion>
+        <clirrPluginVersion>2.8</clirrPluginVersion>
 
         <!-- cobertura-maven-plugin http://mojo.codehaus.org/cobertura-maven-plugin -->
         <coberturaPluginVersion>2.7</coberturaPluginVersion>
 
         <!-- maven-dependency-plugin -->
-        <mavenDependencyPluginVersion>2.10</mavenDependencyPluginVersion>
+        <mavenDependencyPluginVersion>3.1.1</mavenDependencyPluginVersion>
 
         <!-- maven-clean-plugin http://maven.apache.org/components/plugins/maven-clean-plugin -->
-        <mavenCleanPluginVersion>2.6.1</mavenCleanPluginVersion>
+        <mavenCleanPluginVersion>3.1.0</mavenCleanPluginVersion>
 
         <!-- maven-jar-plugin http://maven.apache.org/plugins/maven-jar-plugin/ -->
-        <mavenJarPluginVersion>2.6</mavenJarPluginVersion>
+        <mavenJarPluginVersion>3.1.0</mavenJarPluginVersion>
 
         <!-- maven-war-plugin http://maven.apache.org/plugins/maven-war-plugin/ -->
-        <mavenWarPluginVersion>2.6</mavenWarPluginVersion>
+        <mavenWarPluginVersion>3.2.2</mavenWarPluginVersion>
 
         <!-- maven-assembly-plugin http://maven.apache.org/plugins/maven-assembly-plugin/ -->
-        <mavenAssemblyPluginVersion>2.5.3</mavenAssemblyPluginVersion>
+        <mavenAssemblyPluginVersion>3.1.0</mavenAssemblyPluginVersion>
 
         <!-- maven-surefire-plugin http://maven.apache.org/surefire/maven-surefire-plugin/ -->
-        <mavenSurefirePluginVersion>2.18.1</mavenSurefirePluginVersion>
+        <mavenSurefirePluginVersion>2.22.0</mavenSurefirePluginVersion>
 
         <!-- maven-source-plugin http://maven.apache.org/plugins/maven-source-plugin/ -->
-        <mavenSourcePluginVersion>2.4</mavenSourcePluginVersion>
+        <mavenSourcePluginVersion>3.0.1</mavenSourcePluginVersion>
 
         <!-- maven-resources-plugin http://maven.apache.org/plugins/maven-resources-plugin/ -->
-        <mavenResourcesPluginVersion>2.7</mavenResourcesPluginVersion>
+        <mavenResourcesPluginVersion>3.1.0</mavenResourcesPluginVersion>
 
         <!-- maven-remote-resources-plugin http://maven.apache.org/plugins/maven-remote-resources-plugin/ -->
         <mavenRemoteResourcesPluginVersion>1.5</mavenRemoteResourcesPluginVersion>
@@ -245,16 +245,16 @@
         <mavenInstallPluginVersion>2.5.2</mavenInstallPluginVersion>
 
         <!-- maven-scm-plugin http://maven.apache.org/plugins/maven-scm-plugin/ -->
-        <mavenSCMPluginVersion>1.9.4</mavenSCMPluginVersion>
+        <mavenSCMPluginVersion>1.10.0</mavenSCMPluginVersion>
 
         <!-- license-maven-plugin http://mojo.codehaus.org/license-maven-plugin/ -->
-        <licenseMavenPluginVersion>1.8</licenseMavenPluginVersion>
+        <licenseMavenPluginVersion>1.16</licenseMavenPluginVersion>
 
         <!-- maven-enforcer-plugin http://maven.apache.org/plugins/maven-enforcer-plugin/ -->
-        <mavenEnforcerPluginVersion>1.4</mavenEnforcerPluginVersion>
+        <mavenEnforcerPluginVersion>3.0.0-M2</mavenEnforcerPluginVersion>
 
         <!-- maven-release-plugin http://maven.apache.org/plugins/maven-release-plugin/ -->
-        <mavenReleasePluginVersion>2.5.1</mavenReleasePluginVersion>
+        <mavenReleasePluginVersion>2.5.3</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.2.0-wren1</pgpVerifyPluginVersion>
@@ -299,7 +299,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.7</version>
+                    <version>1.8</version>
                 </plugin>
 
                 <plugin>
@@ -311,7 +311,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.7</version>
+                    <version>3.5.0</version>
 
                     <configuration>
                         <instructions>
@@ -377,13 +377,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-docck-plugin</artifactId>
-                    <version>1.0</version>
+                    <version>1.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-eclipse-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>2.10</version>
                 </plugin>
 
                 <plugin>
@@ -395,7 +395,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.6</version>
                 </plugin>
 
                 <plugin>
@@ -407,7 +407,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>1.7</version>
+                    <version>3.1.0</version>
                 </plugin>
 
                 <plugin>
@@ -419,7 +419,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jarsigner-plugin</artifactId>
-                    <version>1.2</version>
+                    <version>1.4</version>
                 </plugin>
 
                 <plugin>
@@ -455,7 +455,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.5.2</version>
                 </plugin>
 
                 <plugin>
@@ -467,7 +467,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>2.9</version>
                 </plugin>
 
                 <plugin>
@@ -480,7 +480,7 @@
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
                             <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.8.1</version>
+                            <version>1.10.0</version>
                         </dependency>
                     </dependencies>
 
@@ -523,13 +523,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.1.1</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.7.1</version>
 
                     <configuration>
                         <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
@@ -539,7 +539,7 @@
                         <dependency>
                             <groupId>org.apache.maven.wagon</groupId>
                             <artifactId>wagon-ssh</artifactId>
-                            <version>2.2</version>
+                            <version>3.1.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -572,13 +572,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.12.4</version>
+                    <version>2.22.0</version>
                 </plugin>
 
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>${mavenWarPluginVersion}</version>
                 </plugin>
 
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -487,7 +487,7 @@
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <mavenExecutorId>forked-path</mavenExecutorId>
-                        <releaseProfiles>enforce,forgerock-release</releaseProfiles>
+                        <releaseProfiles>enforce,full-release</releaseProfiles>
                         <suppressCommitBeforeTag>false</suppressCommitBeforeTag>
                         <goals>deploy</goals>
                         <tagNameFormat>@{project.version}</tagNameFormat>
@@ -1084,7 +1084,7 @@
         </profile>
 
         <profile>
-            <id>forgerock-release</id>
+            <id>full-release</id>
 
             <build>
                 <plugins>
@@ -1098,7 +1098,7 @@
                         </configuration>
                     </plugin>
 
-                    <!-- Publish also javasources when releasing - required -->
+                    <!-- Publish source JARs when releasing -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -1114,7 +1114,7 @@
                         </executions>
                     </plugin>
 
-                    <!-- Publish also javadocs when releasing - required -->
+                    <!-- Publish Javadoc archives when releasing -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1319,7 +1319,7 @@
 
             <activation>
                 <property>
-                    <name>!ignore-artifact-sigs</name>
+                    <name>!ignoreArtifactSigs</name>
                 </property>
             </activation>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
  Copyright 2011-2016 ForgeRock AS.
- Portions Copyright 2017 Wren Security.
+ Portions Copyright 2017-2018 Wren Security.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -26,8 +26,8 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.forgerock</groupId>
-    <artifactId>forgerock-parent</artifactId>
+    <groupId>org.wrensecurity</groupId>
+    <artifactId>wrensec-parent</artifactId>
     <version>2.0.10</version>
     <packaging>pom</packaging>
     <name>Wren Security Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -255,13 +255,6 @@
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
 
         <wrenBuildToolsVersion>1.0.4</wrenBuildToolsVersion>
-
-        <!-- Forgerock binary license name -->
-        <forgerock.license.name>Forgerock_License.txt</forgerock.license.name>
-        <forgerock.license.output.dir>${project.build.directory}/legal-notices</forgerock.license.output.dir>
-        <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
-        <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
-        <forgerock.license.version>1.0.0</forgerock.license.version>
     </properties>
 
     <prerequisites>
@@ -1241,47 +1234,6 @@
             </plugins>
           </reporting>
         </profile>
-       <profile>
-          <!-- This profile gets the ForgeRock binary license -->
-          <id>binary-licensing</id>
-          <repositories>
-             <repository>
-                <id>forgerock-internal</id>
-                <name>Forgerock Internal Repository</name>
-                <url>http://maven.forgerock.org/repo/internal</url>
-             </repository>
-          </repositories>
-          <build>
-             <plugins>
-                <plugin>
-                   <groupId>org.apache.maven.plugins</groupId>
-                   <artifactId>maven-dependency-plugin</artifactId>
-                   <executions>
-                      <execution>
-                         <id>Copy license</id>
-                         <phase>validate</phase>
-                         <goals>
-                            <goal>copy</goal>
-                         </goals>
-                         <configuration>
-                            <artifactItems>
-                               <artifactItem>
-                                  <groupId>${forgerock.license.groupId}</groupId>
-                                  <artifactId>${forgerock.license.artifactId}</artifactId>
-                                  <version>${forgerock.license.version}</version>
-                                  <type>txt</type>
-                                  <overWrite>true</overWrite>
-                                  <outputDirectory>${forgerock.license.output.dir}</outputDirectory>
-                                  <destFileName>${forgerock.license.name}</destFileName>
-                               </artifactItem>
-                            </artifactItems>
-                         </configuration>
-                      </execution>
-                    </executions>
-                 </plugin>
-              </plugins>
-          </build>
-       </profile>
     </profiles>
 
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,21 @@
  your own identifying information:
  "Portions Copyrighted [year] [name of copyright owner]"
 -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>org.wrensecurity</groupId>
     <artifactId>wrensec-parent</artifactId>
     <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>Wren Security Parent</name>
-    <description>Parent POM for Wren Security (formerly ForgeRock) projects. Provides default project build configuration.</description>
+    <description>Parent POM for Wren Security projects. Provides default project build configuration.</description>
+
     <url>http://wrensecurity.org/</url>
+
     <licenses>
         <license>
             <name>CDDL-1.0</name>
@@ -41,19 +46,23 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <organization>
         <name>Wren Security</name>
         <url>http://wrensecurity.org/</url>
     </organization>
+
     <issueManagement>
         <system>GitHub Issues</system>
         <url>https://github.com/WrenSecurity/wrensec-parent/issues</url>
     </issueManagement>
+
     <scm>
         <url>https://github.com/WrenSecurity/wrensec-parent</url>
         <connection>scm:git:git://github.com/WrenSecurity/wrensec-parent.git</connection>
         <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-parent.git</developerConnection>
     </scm>
+
     <distributionManagement>
         <snapshotRepository>
             <id>wrensecurity-snapshots</id>
@@ -74,6 +83,7 @@
             <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
             <url>${wrenDistMgmtReleasesUrl}</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -87,6 +97,7 @@
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
             <url>${wrenDistMgmtSnapshotsUrl}</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -100,6 +111,7 @@
             <id>wrensecurity-forgerock-archive</id>
             <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
             <url>${forgerockVerifiedArchiveUrl}</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -115,6 +127,7 @@
             <id>wrensecurity-releases</id>
             <name>Wren Security Plugin Release Repository</name>
             <url>${wrenDistMgmtReleasesUrl}</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -124,6 +137,7 @@
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Plugin Snapshot Repository</name>
             <url>${wrenDistMgmtSnapshotsUrl}</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -133,6 +147,7 @@
             <id>wrensecurity-forgerock-archive</id>
             <name>Wren Security Archive for Verified ForgeRock Plugins</name>
             <url>${forgerockVerifiedArchiveUrl}</url>
+
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -274,25 +289,30 @@
                     <artifactId>cobertura-maven-plugin</artifactId>
                     <version>${coberturaPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>findbugs-maven-plugin</artifactId>
                     <version>${findbugsPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.7</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>${mavenAssemblyPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
                     <version>2.3.7</version>
+
                     <configuration>
                         <instructions>
                             <Implementation-Build>${ci.build.number}</Implementation-Build>
@@ -300,33 +320,38 @@
                         </instructions>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>${checkstylePluginVersion}</version>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.forgerock</groupId>
                             <artifactId>forgerock-build-tools</artifactId>
                             <version>${wrenBuildToolsVersion}</version>
                         </dependency>
+
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <version>${checkstyleVersion}</version>
                         </dependency>
                     </dependencies>
-
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
                     <version>${mavenCleanPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${mavenCompilerPluginVersion}</version>
+
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>
@@ -336,56 +361,67 @@
                         <showDeprecation>true</showDeprecation>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${mavenDependencyPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${mavenDeployPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-docck-plugin</artifactId>
                     <version>1.0</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-eclipse-plugin</artifactId>
                     <version>2.9</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>${mavenEnforcerPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.4</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${mavenInstallPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
                     <version>1.7</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${mavenJarPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jarsigner-plugin</artifactId>
                     <version>1.2</version>
                 </plugin>
+
                 <plugin>
                     <!--  See generate-javadoc profile - the configuration here
                           must be aligned with the report configuration
@@ -393,6 +429,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${javadocPluginVersion}</version>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.forgerock</groupId>
@@ -400,6 +437,7 @@
                             <version>${wrenBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
+
                     <configuration>
                         <author>false</author>
                         <quiet>true</quiet>
@@ -413,26 +451,31 @@
                         <stylesheetfile>${javadocStylesheet}</stylesheetfile>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.2</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>${pmdPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>2.6</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>${mavenReleasePluginVersion}</version>
                     <inherited>true</inherited>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
@@ -440,6 +483,7 @@
                             <version>1.8.1</version>
                         </dependency>
                     </dependencies>
+
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <mavenExecutorId>forked-path</mavenExecutorId>
@@ -449,39 +493,48 @@
                         <tagNameFormat>@{project.version}</tagNameFormat>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-remote-resources-plugin</artifactId>
                     <version>${mavenRemoteResourcesPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${mavenResourcesPluginVersion}</version>
+
                     <configuration>
                         <encoding>${project.build.sourceEncoding}</encoding>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-scm-plugin</artifactId>
                     <version>${mavenSCMPluginVersion}</version>
+
                     <configuration>
                         <tag>${project.artifactId}-${project.version}</tag>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.3</version>
+
                     <configuration>
                         <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
                     </configuration>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.wagon</groupId>
@@ -490,15 +543,18 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${mavenSourcePluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${mavenSurefirePluginVersion}</version>
+
                     <dependencies>
                         <dependency>
                             <groupId>org.forgerock</groupId>
@@ -506,26 +562,31 @@
                             <version>${wrenBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
+
                     <configuration>
                         <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
                         <argLine>-Djava.awt.headless=true</argLine>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>2.12.4</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
                     <version>2.6</version>
                 </plugin>
+
                 <plugin>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>plexus-maven-plugin</artifactId>
                     <version>1.3.8</version>
                 </plugin>
+
                 <plugin>
                     <!--This plugin's configuration is used to store Eclipse m2e settings
                         only. It has no influence on the Maven build itself. It's really
@@ -534,6 +595,7 @@
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
                     <version>1.0.0</version>
+
                     <configuration>
                         <lifecycleMappingMetadata>
                             <pluginExecutions>
@@ -542,24 +604,29 @@
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-dependency-plugin</artifactId>
                                         <versionRange>[2.6,)</versionRange>
+
                                         <goals>
                                             <goal>unpack</goal>
                                         </goals>
                                     </pluginExecutionFilter>
+
                                     <action>
                                         <ignore />
                                     </action>
                                 </pluginExecution>
+
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.forgerock.commons</groupId>
                                         <artifactId>i18n-maven-plugin</artifactId>
                                         <versionRange>[1.2.0,)</versionRange>
+
                                         <goals>
                                             <goal>generate-messages</goal>
                                             <goal>generate-test-messages</goal>
                                         </goals>
                                     </pluginExecutionFilter>
+
                                     <action>
                                         <execute>
                                             <runOnIncremental>true</runOnIncremental>
@@ -567,42 +634,51 @@
                                         </execute>
                                     </action>
                                 </pluginExecution>
+
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-enforcer-plugin</artifactId>
                                         <versionRange>[1.0,)</versionRange>
+
                                         <goals>
                                             <goal>enforce</goal>
                                         </goals>
                                     </pluginExecutionFilter>
+
                                     <action>
                                         <ignore />
                                     </action>
                                 </pluginExecution>
+
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>org.codehaus.mojo</groupId>
                                         <artifactId>build-helper-maven-plugin</artifactId>
                                         <versionRange>[1.4,)</versionRange>
+
                                         <goals>
                                             <goal>reserve-network-port</goal>
                                         </goals>
                                     </pluginExecutionFilter>
+
                                     <action>
                                         <ignore />
                                     </action>
                                 </pluginExecution>
+
                                 <pluginExecution>
                                   <pluginExecutionFilter>
                                     <groupId>org.codehaus.mojo</groupId>
                                     <artifactId>xml-maven-plugin</artifactId>
                                     <versionRange>1.0</versionRange>
+
                                     <goals>
                                       <goal>transform</goal>
                                       <goal>validate</goal>
                                     </goals>
                                   </pluginExecutionFilter>
+
                                   <action>
                                     <execute>
                                       <runOnIncremental>true</runOnIncremental>
@@ -610,15 +686,18 @@
                                     </execute>
                                   </action>
                                 </pluginExecution>
+
                                 <pluginExecution>
                                   <pluginExecutionFilter>
                                     <groupId>org.codehaus.mojo</groupId>
                                     <artifactId>buildnumber-maven-plugin</artifactId>
                                     <versionRange>[0,)</versionRange>
+
                                     <goals>
                                       <goal>create</goal>
                                     </goals>
                                   </pluginExecutionFilter>
+
                                   <action>
                                     <execute>
                                       <runOnConfiguration>true</runOnConfiguration>
@@ -630,21 +709,25 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+
                 <plugin>
                     <groupId>com.github.s4u.plugins</groupId>
                     <artifactId>pgpverify-maven-plugin</artifactId>
                     <version>${pgpVerifyPluginVersion}</version>
                 </plugin>
+
                 <plugin>
                     <!-- Check Open Source licenses for all the dependencies -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>${licenseMavenPluginVersion}</version>
+
                     <configuration>
                         <useMissingFile>true</useMissingFile>
                         <fileTemplate>/org/codehaus/mojo/license/third-party-file-groupByLicense.ftl</fileTemplate>
                         <failIfWarning>true</failIfWarning>
                         <excludedScopes>test,provided</excludedScopes>
+
                         <licenseMerges>
                             <licenseMerge>
                                 Apache Software License, Version 2.0|
@@ -662,6 +745,7 @@
                                 Apache Software License - Version 2.0|
                                 Apache License 2.0
                             </licenseMerge>
+
                             <licenseMerge>
                                 Common Development and Distribution License 1.0|
                                 CDDL 1.0|
@@ -674,6 +758,7 @@
                                 Common Development and Distribution License (CDDL) v1.0|
                                 CDDL License
                             </licenseMerge>
+
                             <licenseMerge>
                                 Common Development and Distribution License 1.1|
                                 CDDL 1.1|
@@ -683,6 +768,7 @@
                                 CDDL License, Version 1.1|
                                 Common Development and Distribution License (CDDL) v1.1
                             </licenseMerge>
+
                             <licenseMerge>
                                 The MIT License|
                                 The MIT license|
@@ -690,6 +776,7 @@
                                 MIT license|
                                 MIT
                             </licenseMerge>
+
                             <licenseMerge>
                                 The GNU Lesser General Public License, version 2.1|
                                 LGPL 2.1 license|
@@ -698,12 +785,14 @@
                                 LGPL version 2.1|
                                 GNU Lesser General Public License, Version 2.1
                             </licenseMerge>
+
                             <licenseMerge>
                                 The GNU Lesser General Public License, version 2.0 with Classpath Exception|
                                 GPL2 w/ CPE|
                                 GPLv2+CE|
                                 GPLv2 with classpath exception
                             </licenseMerge>
+
                             <licenseMerge>
                                 The GNU Lesser General Public License, version 3.0|
                                 LGPL 3.0 license|
@@ -712,6 +801,7 @@
                                 LGPL version 3.0|
                                 GNU Lesser General Public License, Version 3.0
                             </licenseMerge>
+
                             <licenseMerge>
                                 BSD|
                                 BSD License|
@@ -720,12 +810,14 @@
                                 The BSD License|
                                 The BSD license
                             </licenseMerge>
+
                             <licenseMerge>
                                 Dual licensed (CDDL and GPL)|
                                 CDDL+GPL|
                                 CDDL+GPL License|
                                 CDDL+GPL license
                             </licenseMerge>
+
                             <licenseMerge>
                                 Dual licensed (CDDL and GPLv2+CE)|
                                 CDDL/GPLv2+CE|
@@ -741,22 +833,27 @@
     <profiles>
         <profile>
             <id>enforce</id>
+
             <activation>
                 <property>
                     <name>!skip-enforce</name>
                 </property>
             </activation>
+
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <id>enforce-plugin-versions</id>
+
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
+
                                 <configuration>
                                     <rules>
                                         <requirePluginVersions>
@@ -769,11 +866,14 @@
                                     </rules>
                                 </configuration>
                             </execution>
+
                             <execution>
                                 <id>enforce-java-version</id>
+
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
+
                                 <configuration>
                                     <rules>
                                         <requireJavaVersion>
@@ -783,11 +883,14 @@
                                     </rules>
                                 </configuration>
                             </execution>
+
                             <execution>
                                 <id>enforce-maven-version</id>
+
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
+
                                 <configuration>
                                     <rules>
                                         <requireMavenVersion>
@@ -802,8 +905,10 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>precommit</id>
+
             <build>
                 <plugins>
                     <plugin>
@@ -818,19 +923,24 @@
                         -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <id>check-src-and-tests</id>
+
                                 <configuration>
                                     <configLocation>${checkstyleSourceConfigLocation}</configLocation>
                                     <headerLocation>${checkstyleHeaderLocation}</headerLocation>
                                     <suppressionsLocation>${checkstyleUnitTestSuppressionsLocation}</suppressionsLocation>
                                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
+
                                     <!-- Only output errors if we're not expecting any -->
                                     <consoleOutput>${checkstyleFailOnError}</consoleOutput>
                                     <failsOnError>${checkstyleFailOnError}</failsOnError>
                                 </configuration>
+
                                 <phase>process-test-classes</phase>
+
                                 <goals>
                                     <goal>checkstyle</goal>
                                 </goals>
@@ -840,11 +950,14 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>metrics</id>
+
             <properties>
                 <testReportsDirectory>${project.build.directory}/surefire-reports/cobertura</testReportsDirectory>
             </properties>
+
             <build>
                 <plugins>
                     <!-- Enforce Checkstyle during compilation -->
@@ -857,15 +970,18 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>cobertura-maven-plugin</artifactId>
+
                         <configuration>
                             <formats>
                                 <format>xml</format>
                                 <format>html</format>
                             </formats>
                         </configuration>
+
                         <executions>
                             <execution>
                                 <phase>package</phase>
+
                                 <goals>
                                     <goal>cobertura</goal>
                                 </goals>
@@ -882,6 +998,7 @@
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>
                         <version>${findbugsPluginVersion}</version>
+
                         <configuration>
                             <xmlOutput>true</xmlOutput>
                             <findbugsXmlOutput>true</findbugsXmlOutput>
@@ -897,6 +1014,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-pmd-plugin</artifactId>
                         <version>${pmdPluginVersion}</version>
+
                         <configuration>
                             <linkXref>true</linkXref>
                             <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
@@ -909,16 +1027,20 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <version>${checkstylePluginVersion}</version>
+
                         <configuration>
                             <configLocation>${checkstyleSourceConfigLocation}</configLocation>
                             <headerLocation>${checkstyleHeaderLocation}</headerLocation>
                             <suppressionsLocation>${checkstyleUnitTestSuppressionsLocation}</suppressionsLocation>
                             <includeTestSourceDirectory>true</includeTestSourceDirectory>
+
                             <!-- Only output errors if we're not expecting any -->
                             <consoleOutput>${checkstyleFailOnError}</consoleOutput>
+
                             <!-- Reports should never fail site generation -->
                             <failsOnError>false</failsOnError>
                         </configuration>
+
                         <reportSets>
                             <reportSet>
                                 <reports>
@@ -930,22 +1052,27 @@
                 </plugins>
             </reporting>
         </profile>
+
         <profile>
             <id>sign</id>
+
             <build>
                 <plugins>
                     <!-- We want to sign the artifact, the POM, and all attached artifacts -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+
                         <configuration>
                             <passphrase>${gpg.passphrase}</passphrase>
                             <useAgent>true</useAgent>
                         </configuration>
+
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
                                 <phase>verify</phase>
+
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
@@ -955,53 +1082,66 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>forgerock-release</id>
+
             <build>
                 <plugins>
                     <plugin>
                         <inherited>true</inherited>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-deploy-plugin</artifactId>
+
                         <configuration>
                             <updateReleaseInfo>true</updateReleaseInfo>
                         </configuration>
                     </plugin>
+
                     <!-- Publish also javasources when releasing - required -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
+
                                 <goals>
                                     <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>
                     </plugin>
+
                     <!-- Publish also javadocs when releasing - required -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
+
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>
                     </plugin>
+
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <id>enforce-maven</id>
+
                                 <goals>
                                     <goal>enforce</goal>
                                 </goals>
+
                                 <configuration>
                                     <rules>
                                         <requireMavenVersion>
@@ -1016,35 +1156,42 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>maven-3</id>
+
             <activation>
                 <file>
                     <!--  This employs that the basedir expression is only recognized by Maven 3.x (see MNG-2363) -->
                     <exists>${basedir}</exists>
                 </file>
             </activation>
+
             <build>
                 <pluginManagement>
                     <plugins>
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-site-plugin</artifactId>
+
                             <configuration>
                                 <outputEncoding>${project.build.sourceEncoding}</outputEncoding>
                             </configuration>
                         </plugin>
                     </plugins>
                 </pluginManagement>
+
                 <plugins>
                     <!-- if releasing current pom with maven 3 site descriptor must be attached -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-site-plugin</artifactId>
                         <inherited>false</inherited>
+
                         <executions>
                             <execution>
                                 <id>attach-descriptor</id>
+
                                 <goals>
                                     <goal>attach-descriptor</goal>
                                 </goals>
@@ -1054,21 +1201,25 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <!--  This profile will automatically generate Javadoc archives
                   during continuous integration.
             -->
             <id>generate-javadoc-jar</id>
+
             <activation>
                 <property>
                     <name>env.JOB_NAME</name>
                 </property>
             </activation>
+
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+
                         <executions>
                             <execution>
                                 <goals>
@@ -1080,6 +1231,7 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <!--  This profile will automatically generate Javadoc reports for
                   modules containing src/main/java and avoids modules from
@@ -1091,18 +1243,21 @@
                   missing functionality).
             -->
             <id>generate-javadoc-report</id>
+
             <activation>
                 <file>
                     <!--  Just require presence of some Java source code -->
                     <exists>src/main/java</exists>
                 </file>
             </activation>
+
             <reporting>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${javadocPluginVersion}</version>
+
                         <configuration>
                             <author>false</author>
                             <quiet>true</quiet>
@@ -1115,6 +1270,7 @@
                             <excludePackageNames>com.*</excludePackageNames>
                             <stylesheetfile>${javadocStylesheet}</stylesheetfile>
                         </configuration>
+
                         <reportSets>
                             <reportSet>
                                 <reports>
@@ -1126,53 +1282,65 @@
                 </plugins>
             </reporting>
         </profile>
+
         <profile>
             <!-- This profile only active if the build server exports the SCM_REVISION variable -->
             <id>ci-build</id>
+
             <activation>
                 <property>
                     <name>env.SCM_REVISION</name>
                 </property>
             </activation>
+
             <properties>
                 <ci.build.number>${env.BUILD_NUMBER}</ci.build.number>
                 <ci.scm.revision>${env.SCM_REVISION}</ci.scm.revision>
             </properties>
         </profile>
+
         <profile>
             <id>non-ci-build</id>
+
             <activation>
                 <property>
                     <name>!env.SCM_REVISION</name>
                 </property>
             </activation>
+
             <properties>
                 <ci.build.number>0</ci.build.number>
                 <ci.scm.revision>0</ci.scm.revision>
             </properties>
         </profile>
+
         <profile>
             <id>verify-artifact-sigs</id>
+
             <activation>
                 <property>
                     <name>!ignore-artifact-sigs</name>
                 </property>
             </activation>
+
             <build>
                 <plugins>
                     <plugin>
                         <groupId>com.github.s4u.plugins</groupId>
                         <artifactId>pgpverify-maven-plugin</artifactId>
+
                         <configuration>
                             <failNoSignature>true</failNoSignature>
                             <keysMapLocation>http://wrensecurity.org/trustedkeys.properties</keysMapLocation>
                             <verifySnapshots>true</verifySnapshots>
                         </configuration>
+
                         <executions>
                             <execution>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
+
                                 <phase>verify</phase>
                             </execution>
                         </executions>
@@ -1180,59 +1348,72 @@
                 </plugins>
             </build>
         </profile>
+
         <profile>
-          <!-- This profile provides API/ABI compatiblity checks and reports via Clirr -->
-          <id>clirr</id>
-          <activation>
-            <file>
-              <exists>clirr-ignored-api-changes.xml</exists><!-- this file name is duplicated due to MNG-4471 -->
-            </file>
-          </activation>
-          <build>
-            <plugins>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <version>${clirrPluginVersion}</version>
-                <inherited>true</inherited>
-                <configuration>
-                  <comparisonVersion>${clirrComparisonVersion}</comparisonVersion>
-                  <excludes>
-                    <exclude>com/**</exclude>
-                  </excludes>
-                  <ignoredDifferencesFile>clirr-ignored-api-changes.xml</ignoredDifferencesFile>
-                </configuration>
-                <executions>
-                  <execution>
-                    <id>mvn clirr:check</id>
-                  </execution>
-                  <execution>
-                    <id>mvn verify</id>
-                    <goals>
-                      <goal>check</goal>
-                    </goals>
-                  </execution>
-                </executions>
-              </plugin>
-            </plugins>
-          </build>
-          <reporting>
-            <plugins>
-              <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>clirr-maven-plugin</artifactId>
-                <version>${clirrPluginVersion}</version>
-                <inherited>true</inherited>
-                <configuration>
-                  <comparisonVersion>${clirrComparisonVersion}</comparisonVersion>
-                  <excludes>
-                    <exclude>com/**</exclude>
-                  </excludes>
-                  <ignoredDifferencesFile>clirr-ignored-api-changes.xml</ignoredDifferencesFile>
-                </configuration>
-              </plugin>
-            </plugins>
-          </reporting>
+            <!-- This profile provides API/ABI compatiblity checks and reports via Clirr -->
+            <id>clirr</id>
+
+            <activation>
+                <file>
+                    <exists>clirr-ignored-api-changes.xml</exists><!-- this file name is duplicated due to MNG-4471 -->
+                </file>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>clirr-maven-plugin</artifactId>
+                        <version>${clirrPluginVersion}</version>
+                        <inherited>true</inherited>
+
+                        <configuration>
+                            <comparisonVersion>${clirrComparisonVersion}</comparisonVersion>
+
+                            <excludes>
+                                <exclude>com/**</exclude>
+                            </excludes>
+
+                            <ignoredDifferencesFile>clirr-ignored-api-changes.xml</ignoredDifferencesFile>
+                        </configuration>
+
+                        <executions>
+                            <execution>
+                                <id>mvn clirr:check</id>
+                            </execution>
+
+                            <execution>
+                                <id>mvn verify</id>
+
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+
+            <reporting>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>clirr-maven-plugin</artifactId>
+                        <version>${clirrPluginVersion}</version>
+                        <inherited>true</inherited>
+
+                        <configuration>
+                            <comparisonVersion>${clirrComparisonVersion}</comparisonVersion>
+
+                            <excludes>
+                                <exclude>com/**</exclude>
+                            </excludes>
+
+                            <ignoredDifferencesFile>clirr-ignored-api-changes.xml</ignoredDifferencesFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </reporting>
         </profile>
     </profiles>
 
@@ -1242,6 +1423,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.4</version>
+
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/pom.xml
+++ b/pom.xml
@@ -165,8 +165,8 @@
 
         <!-- maven-compiler-plugin http://maven.apache.org/plugins/maven-compiler-plugin -->
         <mavenCompilerPluginVersion>3.3</mavenCompilerPluginVersion>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
 
         <!-- maven-enforcer-plugin -->
         <maven.min.version>3.0.1</maven.min.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wrensecurity</groupId>
     <artifactId>wrensec-parent</artifactId>
-    <version>2.0.10</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Wren Security Parent</name>
     <description>Parent POM for Wren Security (formerly ForgeRock) projects. Provides default project build configuration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -58,13 +58,13 @@
         <snapshotRepository>
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}</url>
+            <url>${wrenDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
             <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}</url>
+            <url>${wrenDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
 
@@ -73,7 +73,7 @@
         <repository>
             <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}</url>
+            <url>${wrenDistMgmtReleasesUrl}</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -86,7 +86,7 @@
         <repository>
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}</url>
+            <url>${wrenDistMgmtSnapshotsUrl}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -114,7 +114,7 @@
         <pluginRepository>
             <id>wrensecurity-releases</id>
             <name>Wren Security Plugin Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}</url>
+            <url>${wrenDistMgmtReleasesUrl}</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -123,7 +123,7 @@
         <pluginRepository>
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Plugin Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}</url>
+            <url>${wrenDistMgmtSnapshotsUrl}</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -247,15 +247,14 @@
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
-        <forgerockDistMgmtSnapshotsUrl>https://wrensecurity.jfrog.io/wrensecurity/snapshots</forgerockDistMgmtSnapshotsUrl>
-        <forgerockDistMgmtReleasesUrl>https://wrensecurity.jfrog.io/wrensecurity/releases</forgerockDistMgmtReleasesUrl>
+        <wrenDistMgmtSnapshotsUrl>https://wrensecurity.jfrog.io/wrensecurity/snapshots</wrenDistMgmtSnapshotsUrl>
+        <wrenDistMgmtReleasesUrl>https://wrensecurity.jfrog.io/wrensecurity/releases</wrenDistMgmtReleasesUrl>
         <forgerockVerifiedArchiveUrl>http://dl.bintray.com/wrensecurity/forgerock-archive</forgerockVerifiedArchiveUrl>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
 
-        <!--  ForgeRock build tools version -->
-        <forgerockBuildToolsVersion>1.0.4</forgerockBuildToolsVersion>
+        <wrenBuildToolsVersion>1.0.4</wrenBuildToolsVersion>
 
         <!-- Forgerock binary license name -->
         <forgerock.license.name>Forgerock_License.txt</forgerock.license.name>
@@ -316,7 +315,7 @@
                         <dependency>
                             <groupId>org.forgerock</groupId>
                             <artifactId>forgerock-build-tools</artifactId>
-                            <version>${forgerockBuildToolsVersion}</version>
+                            <version>${wrenBuildToolsVersion}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
@@ -405,7 +404,7 @@
                         <dependency>
                             <groupId>org.forgerock</groupId>
                             <artifactId>forgerock-build-tools</artifactId>
-                            <version>${forgerockBuildToolsVersion}</version>
+                            <version>${wrenBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -511,7 +510,7 @@
                         <dependency>
                             <groupId>org.forgerock</groupId>
                             <artifactId>forgerock-build-tools</artifactId>
-                            <version>${forgerockBuildToolsVersion}</version>
+                            <version>${wrenBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
                     <configuration>


### PR DESCRIPTION
Enhancements:
  - Plug-in and dependency updates.
  - Removal of the FR binary license.
  - Renaming of FR-specific build profiles and vars.
  - Upgrade to Java 8 by default.
  - Fixes convention used for ignoring artifact signatures (now `ignoreArtifactSigs` instead of `ignore-artifact-sigs`).