### PR TITLE
[2.x] Switch to Artifact-based PGP Whitelist + Upgrade PGP Verify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,8 @@
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
-        <pgpVerifyWhitelist>https://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
@@ -1169,6 +1170,27 @@
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-remote-resources-plugin</artifactId>
+
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>process</goal>
+                                </goals>
+
+                                <configuration>
+                                    <resourceBundles>
+                                        <resourceBundle>${pgpWhitelistArtifact}</resourceBundle>
+                                    </resourceBundles>
+
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>org.simplify4u.plugins</groupId>
                         <artifactId>pgpverify-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <mavenReleasePluginVersion>2.5.1</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
-        <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
+        <pgpVerifyPluginVersion>1.3.0-wren3</pgpVerifyPluginVersion>
         <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
         <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,8 @@
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.3.0-wren3</pgpVerifyPluginVersion>
-        <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpVerifyResourcesDir>${project.build.directory}/wrensec-pgp-whitelist</pgpVerifyResourcesDir>
+        <pgpVerifyWhitelist>${pgpVerifyResourcesDir}/trustedkeys.properties</pgpVerifyWhitelist>
         <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 
         <!-- ***************** -->
@@ -1185,7 +1186,7 @@
                                         <resourceBundle>${pgpWhitelistArtifact}</resourceBundle>
                                     </resourceBundles>
 
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <outputDirectory>${pgpVerifyResourcesDir}</outputDirectory>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
This eliminates `wrensec-home` / the Wren website as a single point of failure for PGP verification. It also makes builds more resilient to intermittent PGP key server failures.

Also see: https://github.com/WrenSecurity/wrensec-pgp-whitelist/pull/1