### PR TITLE
[3.x] Switch to Artifact-based PGP Whitelist + Upgrade PGP Verify

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,8 @@
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
-        <pgpVerifyWhitelist>https://wrensecurity.org/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
@@ -1326,6 +1327,27 @@
 
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-remote-resources-plugin</artifactId>
+
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>process</goal>
+                                </goals>
+
+                                <configuration>
+                                    <resourceBundles>
+                                        <resourceBundle>${pgpWhitelistArtifact}</resourceBundle>
+                                    </resourceBundles>
+
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                     <plugin>
                         <groupId>org.simplify4u.plugins</groupId>
                         <artifactId>pgpverify-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,8 @@
 
         <!-- pgpverify-maven-plugin -->
         <pgpVerifyPluginVersion>1.3.0-wren3</pgpVerifyPluginVersion>
-        <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
+        <pgpVerifyResourcesDir>${project.build.directory}/wrensec-pgp-whitelist</pgpVerifyResourcesDir>
+        <pgpVerifyWhitelist>${pgpVerifyResourcesDir}/trustedkeys.properties</pgpVerifyWhitelist>
         <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 
         <!-- ***************** -->
@@ -1342,7 +1343,7 @@
                                         <resourceBundle>${pgpWhitelistArtifact}</resourceBundle>
                                     </resourceBundles>
 
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <outputDirectory>${pgpVerifyResourcesDir}</outputDirectory>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
         <mavenReleasePluginVersion>2.5.3</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
-        <pgpVerifyPluginVersion>1.3.0-wren2</pgpVerifyPluginVersion>
+        <pgpVerifyPluginVersion>1.3.0-wren3</pgpVerifyPluginVersion>
         <pgpVerifyWhitelist>${project.build.directory}/trustedkeys.properties</pgpVerifyWhitelist>
         <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.0.0</pgpWhitelistArtifact>
 


### PR DESCRIPTION
This eliminates wrensec-home / the Wren website as a single point of failure for PGP verification. It also makes builds more resilient to intermittent PGP key server failures.

This is equivalent to https://github.com/WrenSecurity/wrensec-parent/pull/14 but for the new 3.x release of the parent POM.