### PR TITLE
[3.x] Downgrade Maven Enforcer to 3.0.0-M1 from M2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <licenseMavenPluginVersion>1.16</licenseMavenPluginVersion>
 
         <!-- maven-enforcer-plugin http://maven.apache.org/plugins/maven-enforcer-plugin/ -->
-        <mavenEnforcerPluginVersion>3.0.0-M2</mavenEnforcerPluginVersion>
+        <mavenEnforcerPluginVersion>3.0.0-M1</mavenEnforcerPluginVersion>
 
         <!-- maven-release-plugin http://maven.apache.org/plugins/maven-release-plugin/ -->
         <mavenReleasePluginVersion>2.5.3</mavenReleasePluginVersion>


### PR DESCRIPTION
this works around [MENFORCER-306](https://issues.apache.org/jira/browse/MENFORCER-306) which was causing all of our plugins to fail the `RequirePluginVersions` rule.

once MENFORCER-306 is resolved and released in the final version of 3.0.0, we can upgrade to that Enforcer release.