### PR TITLE
[2.x] Merge: ForgeRock's Last CDDL Commits into `sustaining/2.x`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.13</version>
+    <version>2.0.14-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.13</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.12-SNAPSHOT</version>
+    <version>2.0.12</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.12</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -484,7 +484,7 @@
                     </dependencies>
                     <configuration>
                         <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
-                        <argLine>-Djava.awt.headless=true</argLine>
+                        <argLine>@{argLine} -Djava.awt.headless=true</argLine>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.9-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.8</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.9</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.9</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -801,20 +801,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <!-- Check Open Source licenses for all the dependencies -->
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>license-maven-plugin</artifactId>
-                        <version>1.7</version>
-                        <executions>
-                            <execution>
-                                <id>generate-oss-license-report</id>
-                                <goals>
-                                    <goal>add-third-party</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.0.14</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.14</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright 2011-2015 ForgeRock AS.
+ Copyright 2011-2016 ForgeRock AS.
 
  The contents of this file are subject to the terms
  of the Common Development and Distribution License
@@ -442,7 +442,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.14</version>
+    <version>2.0.15-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.14</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.12</version>
+    <version>2.0.13-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.12</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,8 @@
         <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
         <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
         <forgerock.license.version>1.0.0</forgerock.license.version>
-        <!-- Keep this line until removal of @{argLine} in surefire plugin configuration -->
-        <argLine />
+        <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
+        <argLine>-Djava.awt.headless=true</argLine>
     </properties>
 
     <prerequisites>
@@ -484,10 +484,6 @@
                             <version>${forgerockBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
-                    <configuration>
-                        <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
-                        <argLine>@{argLine} -Djava.awt.headless=true</argLine>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.14-SNAPSHOT</version>
+    <version>2.0.13-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <mavenWarPluginVersion>2.6</mavenWarPluginVersion>
 
         <!-- maven-assembly-plugin http://maven.apache.org/plugins/maven-assembly-plugin/ -->
-        <mavenAssemblyPluginVersion>2.5.3</mavenAssemblyPluginVersion>
+        <mavenAssemblyPluginVersion>2.5.5</mavenAssemblyPluginVersion>
 
         <!-- maven-surefire-plugin http://maven.apache.org/surefire/maven-surefire-plugin/ -->
         <mavenSurefirePluginVersion>2.18.1</mavenSurefirePluginVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.10</version>
+    <version>2.0.11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.10</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.7-SNAPSHOT</version>
+    <version>2.0.8</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.8</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.13-SNAPSHOT</version>
+    <version>2.0.13</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.13</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>
@@ -232,7 +232,7 @@
         <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
         <forgerock.license.version>1.0.0</forgerock.license.version>
         <!-- Keep this line until removal of @{argLine} in surefire plugin configuration -->
-        <argLine></argLine>
+        <argLine />
     </properties>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.10-SNAPSHOT</version>
+    <version>2.0.10</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.10</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.9</version>
+    <version>2.0.10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.9</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.6</version>
+    <version>2.0.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.6</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.8-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.8</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,11 @@
         <forgerockBuildToolsVersion>1.0.4</forgerockBuildToolsVersion>
 
         <!-- Forgerock binary license name -->
-        <binary.license.name>Forgerock_License.txt</binary.license.name>
+        <forgerock.license.name>Forgerock_License.txt</forgerock.license.name>
+        <forgerock.license.output.dir>${project.build.directory}/legal-notices</forgerock.license.output.dir>
+        <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
+        <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
+        <forgerock.license.version>1.0.0</forgerock.license.version>
     </properties>
 
     <prerequisites>
@@ -1162,71 +1166,44 @@
           </reporting>
         </profile>
        <profile>
-          <!-- This profile gets the license from SVN if the URL is set -->
-          <id>get-binary-license</id>
-          <activation>
-             <property>
-                <name>binary.license.url</name>
-             </property>
-          </activation>
+          <!-- This profile gets the ForgeRock binary license -->
+          <id>binary-licensing</id>
+          <repositories>
+             <repository>
+                <id>forgerock-internal</id>
+                <name>Forgerock Internal Repository</name>
+                <url>http://maven.forgerock.org/repo/internal</url>
+             </repository>
+          </repositories>
           <build>
              <plugins>
                 <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
-                   <artifactId>maven-antrun-plugin</artifactId>
+                   <artifactId>maven-dependency-plugin</artifactId>
                    <executions>
                       <execution>
-                         <id>get-license-from-svn</id>
+                         <id>Copy license</id>
+                         <phase>validate</phase>
                          <goals>
-                            <goal>run</goal>
+                            <goal>copy</goal>
                          </goals>
-                         <phase>prepare-package</phase>
                          <configuration>
-                            <target>
-                               <taskdef resource="net/sf/antcontrib/antcontrib.properties" classpathref="maven.plugin.classpath" />
-                               <if>
-                                  <!-- To include the license in the binary, the project must set another property (include.binary.license) -->
-                                  <!-- This property contains the target folder to export the binary license -->
-                                  <isset property="include.binary.license" />
-                                  <then>
-                                     <echo message="Fetching license from SVN" />
-                                     <!-- The Maven SCM plugin clean the target folder when using the export command (it's a bug...) -->
-                                     <!-- That's why we are using the svn export command -->
-                                     <mkdir dir="${include.binary.license}" />
-                                     <exec dir="${include.binary.license}" executable="svn">
-                                        <arg value="export" />
-                                        <arg value="${binary.license.url}" />
-                                        <arg value="${include.binary.license}/${binary.license.name}" />
-                                     </exec>
-                                  </then>
-                                  <else>
-                                     <echo message="License not fetched from SVN for this project" />
-                                  </else>
-                               </if>
-                            </target>
+                            <artifactItems>
+                               <artifactItem>
+                                  <groupId>${forgerock.license.groupId}</groupId>
+                                  <artifactId>${forgerock.license.artifactId}</artifactId>
+                                  <version>${forgerock.license.version}</version>
+                                  <type>txt</type>
+                                  <overWrite>true</overWrite>
+                                  <outputDirectory>${forgerock.license.output.dir}</outputDirectory>
+                                  <destFileName>${forgerock.license.name}</destFileName>
+                               </artifactItem>
+                            </artifactItems>
                          </configuration>
                       </execution>
-                   </executions>
-                   <dependencies>
-                      <dependency>
-                         <groupId>ant-contrib</groupId>
-                         <artifactId>ant-contrib</artifactId>
-                         <version>1.0b3</version>
-                         <exclusions>
-                            <exclusion>
-                               <groupId>ant</groupId>
-                               <artifactId>ant</artifactId>
-                            </exclusion>
-                         </exclusions>
-                      </dependency>
-                      <dependency>
-                         <groupId>org.apache.ant</groupId>
-                         <artifactId>ant-nodeps</artifactId>
-                         <version>1.8.1</version>
-                      </dependency>
-                   </dependencies>
-                </plugin>
-             </plugins>
+                    </executions>
+                 </plugin>
+              </plugins>
           </build>
        </profile>
     </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1171,6 +1171,11 @@
        <profile>
           <!-- This profile gets the ForgeRock binary license -->
           <id>binary-licensing</id>
+          <activation>
+             <file>
+                <exists>include_forgerock_license</exists>
+             </file>
+          </activation>
           <repositories>
              <repository>
                 <id>forgerock-internal</id>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.11-SNAPSHOT</version>
+    <version>2.0.11</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.11</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.9-SNAPSHOT</version>
+    <version>2.0.8</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.8</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.13-SNAPSHOT</version>
+    <version>2.0.13</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.13</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,8 @@
         <forgerock.license.groupId>com.forgerock</forgerock.license.groupId>
         <forgerock.license.artifactId>binary-license</forgerock.license.artifactId>
         <forgerock.license.version>1.0.0</forgerock.license.version>
+        <!-- Keep this line until removal of @{argLine} in surefire plugin configuration -->
+        <argLine></argLine>
     </properties>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,10 @@
                             <version>${forgerockBuildToolsVersion}</version>
                         </dependency>
                     </dependencies>
+                    <configuration>
+                        <!-- prevent the annoying ForkedBooter process from stealing window focus on Mac OS -->
+                        <argLine>-Djava.awt.headless=true</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <checkstyleHeaderLocation>org/forgerock/checkstyle/default-java-header</checkstyleHeaderLocation>
         <checkstyleFailOnError>true</checkstyleFailOnError>
 
-        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version 
+        <!-- Thanks to the usage of properties, each project using this POM as parent-pom can easily use its own plugin version
              (useful when you have some constraints on a given version and if the parent doesn't give you the one you need ...) -->
 
         <!-- clirr-maven-plugin -->
@@ -220,7 +220,7 @@
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>
 
         <!--  ForgeRock build tools version -->
-        <forgerockBuildToolsVersion>1.0.3</forgerockBuildToolsVersion>
+        <forgerockBuildToolsVersion>1.0.4</forgerockBuildToolsVersion>
 
         <!-- Forgerock binary license name -->
         <binary.license.name>Forgerock_License.txt</binary.license.name>
@@ -778,7 +778,7 @@
                              to fail the build if source code does not comply with
                              our coding guidelines, and not at a later stage when
                              the site is generated (which may never occur for some
-                             projects).     
+                             projects).
                         -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
@@ -883,7 +883,7 @@
                     </plugin>
 
                     <!-- CheckStyle -->
-                    <plugin> 
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-checkstyle-plugin</artifactId>
                         <version>${checkstylePluginVersion}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <repository>
             <id>forgerock-staging-repository</id>
             <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <url>https://maven.forgerock.org/repo/releases</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -88,7 +88,7 @@
         <repository>
             <id>forgerock-snapshots-repository</id>
             <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <url>https://maven.forgerock.org/repo/snapshots</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -101,7 +101,7 @@
         <pluginRepository>
             <id>forgerock-plugins-repository</id>
             <name>ForgeRock Plugin Repository</name>
-            <url>http://maven.forgerock.org/repo/plugins</url>
+            <url>https://maven.forgerock.org/repo/plugins</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -213,8 +213,8 @@
         <!-- ***************** -->
         <!-- Repository Deployment URLs -->
         <!-- ***************** -->
-        <forgerockDistMgmtSnapshotsUrl>http://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
-        <forgerockDistMgmtReleasesUrl>http://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
+        <forgerockDistMgmtSnapshotsUrl>https://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
+        <forgerockDistMgmtReleasesUrl>https://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.11</version>
+    <version>2.0.12-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>2.0.11</tag>
+      <tag>HEAD</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.forgerock</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.8-SNAPSHOT</version>
+    <version>2.0.8</version>
     <packaging>pom</packaging>
     <name>ForgeRock Parent</name>
     <description>Parent POM for ForgeRock projects. Provides default project build configuration.</description>
@@ -52,7 +52,7 @@
         <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</connection>
         <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-parent.git</developerConnection>
         <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-parent/browse</url>
-      <tag>HEAD</tag>
+      <tag>2.0.8</tag>
   </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,9 @@
         <pmdPluginVersion>3.4</pmdPluginVersion>
         <targetJdk>${maven.compiler.target}</targetJdk>
 
+        <!-- Checkstyle version -->
+        <checkstyleVersion>6.6</checkstyleVersion>
+
         <!-- maven-checkstyle-plugin -->
         <checkstylePluginVersion>2.16</checkstylePluginVersion>
         <checkstyleSourceConfigLocation>org/forgerock/checkstyle/check-src-default.xml</checkstyleSourceConfigLocation>
@@ -286,7 +289,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.6</version>
+                            <version>${checkstyleVersion}</version>
                         </dependency>
                     </dependencies>
 


### PR DESCRIPTION
This brings in any changes to `forgerock-parent` up to 2.0.14 that ForgeRock had made public via Notifyr email notifications from BitBucket/Stash. We had nearly 100% of these changes already, via source JARs; what this PR mainly adds is additional project history/context for why certain changes were made.

At least one commit from FR is known to be missing (the version bump from `2.0.7-SNAPSHOT` to `2.0.7`); others are assumed to be missing as well. The version bump was simulated (by me) via a manual edit in 49c174d.

All of the commits added in this PR are from publicly available [`forgerock-commons` mailing list postings](http://forgerock-commons.1100771.n5.nabble.com/). The original messages from which the commits were reconstituted are available for audit, and have been archived here:
https://github.com/WrenArchiver/forgerock-notifyr-archive/tree/master/organized_notifications/forgerock-parent/master

In [c608546803d68f063d209d883bb249f03f81ce18 on 2017-02-08 (RELENG-92)](https://htmlpreview.github.io/?https://github.com/WrenArchiver/forgerock-notifyr-archive/blob/cff50de078a71a7cb290978ef936536a21c1efdc/organized_notifications/forgerock-parent/master/20170215--2017-02-08--15-22-45--c608546803d68f063d209d883bb249f03f81ce18--msg-9254aa97.html) ForgeRock officially changed licensing on the repo to its proprietary, commercial license. To respect and comply with this change in licensing, no Notifyr notifications for this commit -- or any commits thereafter -- were imported.