### PR TITLE
Remove bintray repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,20 +97,6 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-
-        <repository>
-            <id>wrensecurity-forgerock-archive</id>
-            <name>Wren Security Archive for Verified ForgeRock Artifacts</name>
-            <url>${forgerockVerifiedArchiveUrl}</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -128,16 +114,6 @@
             <id>wrensecurity-snapshots</id>
             <name>Wren Security Plugin Snapshot Repository</name>
             <url>${wrenDistMgmtSnapshotsUrl}</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-
-        <pluginRepository>
-            <id>wrensecurity-forgerock-archive</id>
-            <name>Wren Security Archive for Verified ForgeRock Plugins</name>
-            <url>${forgerockVerifiedArchiveUrl}</url>
 
             <snapshots>
                 <enabled>true</enabled>
@@ -247,7 +223,6 @@
         <!-- Repository Deployment URLs -->
         <wrenDistMgmtSnapshotsUrl>https://wrensecurity.jfrog.io/wrensecurity/snapshots</wrenDistMgmtSnapshotsUrl>
         <wrenDistMgmtReleasesUrl>https://wrensecurity.jfrog.io/wrensecurity/releases</wrenDistMgmtReleasesUrl>
-        <forgerockVerifiedArchiveUrl>http://dl.bintray.com/wrensecurity/forgerock-archive</forgerockVerifiedArchiveUrl>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>


### PR DESCRIPTION
As an aftermath of https://www.jfrog.com/confluence/pages/viewpage.action?pageId=122564110

The bintray repository has been removed from parent pom.