### PR TITLE
Fix JavaDoc site styles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,6 @@
         <javadocPluginVersion>3.4.1</javadocPluginVersion>
         <javadocWindowTitle>${project.name} ${project.version} Documentation</javadocWindowTitle>
         <javadocDocTitle>${javadocWindowTitle}</javadocDocTitle>
-        <javadocStylesheet>org/forgerock/javadoc/javadoc.css</javadocStylesheet>
 
         <!-- maven-pmd-plugin -->
         <pmdPluginVersion>3.19.0</pmdPluginVersion>
@@ -534,7 +533,6 @@
                         <additionalparam>-linksource</additionalparam>
                         <show>protected</show>
                         <excludePackageNames>com.*</excludePackageNames>
-                        <stylesheetfile>${javadocStylesheet}</stylesheetfile>
                     </configuration>
                 </plugin>
 
@@ -995,7 +993,6 @@
                             <additionalparam>-linksource</additionalparam>
                             <show>protected</show>
                             <excludePackageNames>com.*</excludePackageNames>
-                            <stylesheetfile>${javadocStylesheet}</stylesheetfile>
                         </configuration>
 
                         <reportSets>


### PR DESCRIPTION
I removed custom JavaDoc site stylesheet file because it overrides the default styles. The custom stylesheet file does not contain any valuable styles.