### PR TITLE
Fix JavaDoc plugin linksource configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
                         <doctitle>${javadocDocTitle}</doctitle>
                         <header><![CDATA[<b>${javadocDocTitle}</b>]]></header>
                         <footer><![CDATA[<b>${javadocDocTitle}</b>]]></footer>
-                        <additionalparam>-linksource</additionalparam>
+                        <linksource>true</linksource>
                         <show>protected</show>
                         <excludePackageNames>com.*</excludePackageNames>
                     </configuration>


### PR DESCRIPTION
JavaDoc plugin configuration attribute `additionalparam` is not available anymore. Linksource configuration should be performed using dedicated attribute https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#linksource.