### PR TITLE
Upgrade PGP Maven Plugin to support revoked keys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,11 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Check
       run: mvn -B verify

--- a/pom.xml
+++ b/pom.xml
@@ -214,10 +214,10 @@
         <mavenReleasePluginVersion>3.0.0-M7</mavenReleasePluginVersion>
 
         <!-- pgpverify-maven-plugin -->
-        <pgpVerifyPluginVersion>1.16.0</pgpVerifyPluginVersion>
+        <pgpVerifyPluginVersion>1.19.0</pgpVerifyPluginVersion>
         <pgpVerifySnapshots>false</pgpVerifySnapshots>
         <pgpVerifyKeysFile>/wrensec-trusted-keys.list</pgpVerifyKeysFile>
-        <pgpVerifyKeysVersion>1.7.0</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.8.3</pgpVerifyKeysVersion>
 
         <!-- this property makes sure NetBeans 6.8+ picks up some formatting rules from checkstyle -->
         <netbeans.checkstyle.format>true</netbeans.checkstyle.format>


### PR DESCRIPTION
This PR upgrades PGP Maven Plugin to the latest release to support revoked keys.