### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/WrenSecurity/wrensec-parent/security/code-scanning/1](https://github.com/WrenSecurity/wrensec-parent/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow so that the `GITHUB_TOKEN` is limited to the least privileges required. For this build job, the steps only need to read repository contents; they do not need to write to the repo, issues, or pull requests. Therefore, setting `contents: read` is an appropriate minimal scope.

The best way to fix this specific workflow without changing existing behavior is to add a `permissions` block at the workflow root level (top-level, beside `name` and `on`). This will apply to all jobs that do not declare their own permissions, which matches our case with a single `build` job. Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: Build` line and the `on:` block, preserving indentation consistent with YAML top-level keys. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
