### PR TITLE
Ignore push event on dependabot branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   push:
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
Dependabot creates a branch and a PR. Actions will be triggered for both without this change.